### PR TITLE
fix argument name

### DIFF
--- a/JoyStickView/Src/JoyStickView.swift
+++ b/JoyStickView/Src/JoyStickView.swift
@@ -236,7 +236,7 @@ extension JoyStickView {
                                           kCIInputColorKey: CIColor(color: handleTintColor!),
                                           kCIInputImageKey: inputImage]
 
-        guard let filter = CIFilter(name: "CIColorMonochrome", parameters: filterConfig) else {
+        guard let filter = CIFilter(name: "CIColorMonochrome", withInputParameters: filterConfig) else {
             fatalError("failed to create CIFilter CIColorMonochrome")
         }
 


### PR DESCRIPTION
On iOS SDK 11.3, I was getting this compiler error:

```
xxx/Joystick-master/JoyStickView/Src/JoyStickView.swift:239:28: Argument labels '(name:, parameters:)' do not match any available overloads

xxx/Joystick-master/JoyStickView/Src/JoyStickView.swift:239:28: Overloads for 'CIFilter' exist with these partially matching parameter lists: (name: String, withInputParameters: [String : Any]?), (imageURL: URL!, options: [AnyHashable : Any]!), (imageData: Data!, options: [AnyHashable : Any]!), (cvPixelBuffer: CVPixelBuffer!, properties: [AnyHashable : Any]!, options: [AnyHashable : Any]!), (CVPixelBuffer: CVPixelBuffer!, properties: [AnyHashable : Any]!, options: [AnyHashable : Any]!)
```

Thanks for sharing this -- it's clear you put love in it, especially the documentation.